### PR TITLE
Fix code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/server.js
+++ b/server.js
@@ -48,10 +48,13 @@ function getSubdomain(req, rewrite) {
     if (rewrite) {
       req.url = res[0];
     }
-    sub = res[1];
+    sub = res[1].replace(/\.$/, '');
   } else {
     const hostDomain = req.headers.host;
-    sub = hostDomain.slice(0, hostDomain.lastIndexOf('.', hostDomain.lastIndexOf('.') - 1) + 1);
+    sub = hostDomain.slice(0, hostDomain.lastIndexOf('.', hostDomain.lastIndexOf('.') - 1) + 1).replace(/\.$/, '');
+  }
+  if (!allowedSubdomains.includes(sub)) {
+    sub = 'www';
   }
   return sub;
 }
@@ -118,7 +121,7 @@ app.use(function (req, res, next) {
 
   const subdomain = getSubdomain(req, true);
   const proto = req.protocol;
-  const target = `${proto}://${subdomain || 'www.'}roblox.com`;
+  const target = `${proto}://${subdomain}.roblox.com`;
 
   console.log(`Proxying to: ${target}`);
   const options = { target };


### PR DESCRIPTION
Fixes [https://github.com/Phalanxia/rprxy/security/code-scanning/1](https://github.com/Phalanxia/rprxy/security/code-scanning/1)

To fix the SSRF vulnerability, we need to ensure that the `target` URL is constructed in a way that does not allow user input to control the hostname. We can achieve this by using a fixed set of allowed subdomains and constructing the `target` URL based on these subdomains. This way, we avoid directly incorporating user input into the URL.

1. Modify the `getSubdomain` function to return a fixed subdomain based on the user input.
2. Ensure that the `target` URL is constructed using this fixed subdomain.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
